### PR TITLE
Fix catalog.product.attribute.get to handle both get by searchCriteria and attribute_code

### DIFF
--- a/lib/catalog/product/attribute.js
+++ b/lib/catalog/product/attribute.js
@@ -43,7 +43,19 @@ module.exports = function(service) {
     }
   }
 
-  attribute.get = (code) => service.get(service._format(urls.attribute, {attributeCode: code || ''}))
+  attribute.get = (param) => {
+    let url
+    let pathParams = {}
+    let query = {}
+    if(typeof param == 'object' || typeof param == 'undefined') {
+      url = urls.attributes;
+      query = param;
+    } else {
+      url = urls.attribute;
+      pathParams.attributeCode = param;
+    }
+    return service.get(service._format(url, pathParams), query);
+  }
   attribute.post = (data) => service.post(urls.attributes, data)
   attribute.delete = (code) => service.delete(service._format(urls.attribute, {attributeCode: code}))
 


### PR DESCRIPTION
Before the change it wasn't possible to pass ```searchCriteria``` to ```catalog.product.attribute.get()```