### PR TITLE
http basic auth, fixed init() and auth key initiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install node-magento2
 
 const Magento2 = require('node-magento2');
 
-//instantiate the client object
+//instantiate the client object with access token
 const options = {
   authentication: {
     integration: {
@@ -56,7 +56,7 @@ Helpers add a Javascript style API to generate the URLs.
 
 const Magento2 = require('node-magento2');
 
-//instantiate the client object
+//instantiate the client object using access token
 const options = {
   authentication: {
     integration: {
@@ -74,7 +74,82 @@ mageClient.init();
 mageClient.catalog.product.get('SKU_123').then(product => {}) //get a product
 mageClient.configProduct('CONFIG_123').options.get().then(options => {}) //get the options for a configurable
 ```
+ 
+## Using a Magento account to login 
+You can use a Magento admin or customer account to generate an access token
 
+```javascript
+"use strict";
+
+const Magento2 = require('node-magento2');
+
+//instantiate the client object using access token
+const options = {
+  authentication: {
+    login: {
+      username: 'apiuser',
+      password: 'password123',
+      type: 'admin',
+    },
+  }
+}
+
+const mageClient = new Magento2('http://magento.root.url', options)
+
+//initialise the helpers & generate a token
+mageClient.init(m2 => {
+  //use the api 
+  m2.put('/V1/products/SKU_123', {visibility: 1}) //update product SKU_123
+    .then(product => {
+      //product data that's been modified to be invisible
+    })
+});
+```
+## Using Basic HTTP Auth
+Magento's API uses a HTTP Authorization header to authenticate.
+Multiple authorization headers do not work with all web servers.
+If your dev/staging server is protected behind Basic HTTP Auth the client will send the Basic Auth header as the HTTP Authentication header.
+The Magento authentication header is moved to a header called X-Auth.
+To get Magento/PHP to read the authentication header/token your server can be configured to pass the X-Auth HTTP header to PHP as the Authorization header.
+
+e.g. on nginx with PHP-FPM
+
+```shell
+    fastcgi_param  HTTP_AUTHORIZATION $http_x_auth;
+```
+
+```javascript
+"use strict";
+
+const Magento2 = require('node-magento2');
+
+//instantiate the client object using access token
+const options = {
+  authentication: {
+    login: {
+      username: 'apiuser',
+      password: 'password123',
+      type: 'admin',
+    },
+    basic: {
+      username: 'httpuser',
+      password: 'httppassword'
+    }
+  }
+}
+
+const mageClient = new Magento2('http://magento.root.url', options)
+
+//initialise the helpers & generate a token
+mageClient.init(m2 => {
+  //use the api 
+  m2.put('/V1/products/SKU_123', {visibility: 1}) //update product SKU_123
+    .then(product => {
+      //product data that's been modified to be invisible
+    })
+});
+```
+ 
 ## Options Object
 
 ```javascript
@@ -92,6 +167,10 @@ mageClient.configProduct('CONFIG_123').options.get().then(options => {}) //get t
       consumer_secret: undefined,
       access_token: undefined,
       access_token_secret: undefined
+    },
+    basic: {
+      username: 'bobbytables',
+      password: 'password123'
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ class MagentoTwo {
     this.options = deepmerge(defaultOptions, options);
     this.rootPath = 'rest/'+this.options.store;
     this.authKey = false;
+    if(this.options.authentication.integration.access_token) {
+      this.authKey = this.options.authentication.integration.access_token;
+    }
   }
 
   init() {
@@ -55,7 +58,7 @@ class MagentoTwo {
         } else {
           path = '/V1/integration/customer/token'
         }
-        this.post(path, {username: this.options.authentication.login.username, password: this.options.authentication.login.password})
+        return this.post(path, {username: this.options.authentication.login.username, password: this.options.authentication.login.password})
           .then(token => {
             this.authKey = token;
             resolve(this);
@@ -63,8 +66,6 @@ class MagentoTwo {
           .catch(e => {
             reject(e);
           });
-      } else if(this.options.authentication.integration.access_token) {
-        this.authKey = this.options.authentication.integration.access_token;
       }
       resolve(this);
     });
@@ -117,6 +118,14 @@ class MagentoTwo {
     headers['Content-Type'] = 'application/json';
     if(this.authKey) {
       headers.Authorization = 'Bearer '+this.authKey;
+    }
+    if(this.options.authentication.basic.username && this.options.authentication.basic.password) {
+      headers.Authorization = "Basic " 
+        + new Buffer(this.options.authentication.basic.username 
+        + ":" + this.options.authentication.basic.password).toString("base64");
+      if(this.authKey) {
+        headers['X-Auth'] = 'Bearer '+this.authKey;
+      }
     }
     return new Promise((resolve, reject) => {
       request({


### PR DESCRIPTION
Hi, 

Thanks for this module. I've made a few improvements/fixes. 

First - I had to make an addition to pass through HTTP Basic Authentication on a development server.

Second - the auth token was never set unless the init() method was called. I've moved the auth token instantiation into the constructor & fixed the init() method to return the result of its resolve() function to the post method when authentication is via user/password.