### PR TITLE
Fixed passing data in an order/#/ship call

### DIFF
--- a/lib/sales/order.js
+++ b/lib/sales/order.js
@@ -65,7 +65,7 @@ module.exports = function(service){
         post: () => service.post(service._format(urls.orderUnhold, pathParams))
       },
       ship: {
-        post: () => service.post(service._format(urls.orderShip, pathParams))
+        post: (data) => service.post(service._format(urls.orderShip, pathParams), data)
       },
       invoice: {
         post: () => service.post(service._format(urls.orderInvoice, pathParams))


### PR DESCRIPTION
Calling order/#/ship did not pass the order_items, tracks, notify... data to the magento store.